### PR TITLE
Update GitHub Actions workflows to latest Homebrew template

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,28 +10,32 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
     runs-on: ubuntu-22.04
     permissions:
+      actions: read
+      checks: read
       contents: write
+      issues: read
       packages: write
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@main
 
       - name: Pull bottles
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
-          token: ${{ github.token }}
           branch: main
 
       - name: Delete branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,20 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-15]
+        os: [ ubuntu-22.04, macos-15-intel, macos-26 ]
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      packages: read
+      pull-requests: read
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Homebrew Bundler RubyGems
         uses: actions/cache@v4
@@ -29,9 +37,19 @@ jobs:
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-tap-syntax
-
-      - run: brew test-bot --only-formulae --root-url='https://ghcr.io/v2/msakai/tap'
+      - name: Base64-encode GITHUB_TOKEN for HOMEBREW_DOCKER_REGISTRY_TOKEN
+        id: base64-encode
         if: github.event_name == 'pull_request'
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          base64_token=$(echo -n "${TOKEN}" | base64 | tr -d "\n")
+          echo "::add-mask::${base64_token}"
+          echo "token=${base64_token}" >> "${GITHUB_OUTPUT}"
+      - run: brew test-bot --only-formulae --root-url=https://ghcr.io/v2/msakai/tap
+        if: github.event_name == 'pull_request'
+        env:
+          HOMEBREW_DOCKER_REGISTRY_TOKEN: ${{ steps.base64-encode.outputs.token }}
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,20 @@ brew test <name>
 - **mingw-w64-dwarf2** — MinGW-w64 cross-compiler targeting i686 with DWARF2 exceptions (differs from upstream `mingw-w64` which uses SJLJ); multi-stage bootstrap build (binutils → headers → gcc stage1 → crt → winpthreads → gcc full)
 - **scip-dev** — SCIP mixed integer programming solver; built from a specific git revision of the v10-minor branch using `cmake`
 
+## Updating GitHub Actions Workflows
+
+Homebrew does not provide a built-in command to update workflows for an existing tap. `brew tap-new` only generates templates for new taps. To update workflows to match the latest Homebrew template:
+
+1. Generate a fresh tap in a temporary namespace and compare:
+   ```bash
+   brew tap-new --no-git --github-packages tmp/test-tap
+   diff .github/workflows/tests.yml "$(brew --repository)/Library/Taps/tmp/test-tap/.github/workflows/tests.yml"
+   diff .github/workflows/publish.yml "$(brew --repository)/Library/Taps/tmp/test-tap/.github/workflows/publish.yml"
+   brew untap tmp/test-tap
+   ```
+2. Apply the relevant changes (e.g., runner OS matrix updates) manually.
+3. The canonical template source is [`tap-new.rb`](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/dev-cmd/tap-new.rb).
+
 ## Conventions
 
 - Bottles are hosted on GHCR at `ghcr.io/v2/msakai/tap`


### PR DESCRIPTION
## Summary
- Update CI runner matrix from `[ubuntu-22.04, macos-13, macos-15]` to `[ubuntu-22.04, macos-15-intel, macos-26]` (macos-13 has been deprecated by GitHub Actions)
- Update Homebrew actions references from `@master` to `@main`
- Add explicit permissions and token configuration to match the latest `brew tap-new` template
- Document workflow update process in CLAUDE.md

## Test plan
- [x] Verify CI passes on the new runner matrix
- [ ] Confirm bottles are built and uploaded correctly for each platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)